### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate, Azure Models - using litellm

### DIFF
--- a/evaluation/get_score_from_freetext.py
+++ b/evaluation/get_score_from_freetext.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 import pandas as pd
 from tqdm import tqdm
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatLiteLLM
 
 
 if __name__ == "__main__":
@@ -24,7 +24,7 @@ if __name__ == "__main__":
 
     scores_ab = defaultdict(list)
 
-    chat = ChatOpenAI(model_name='gpt-3.5-turbo')
+    chat = ChatLiteLLM(model_name='gpt-3.5-turbo')
     for _, row in tqdm(df.iterrows(), total=len(df)):
         text_score = row['result']
 

--- a/evaluation/llm_eval.py
+++ b/evaluation/llm_eval.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 from tqdm import tqdm
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatLiteLLM
 from langchain.llms import Anthropic
 
 logging.basicConfig(level=logging.INFO)
@@ -171,13 +171,7 @@ if __name__ == "__main__":
 
     model_name = args.judge_name
     temperature = 0
-    if "gpt-3.5" in model_name or "gpt-4" in model_name:
-        chat = ChatOpenAI(temperature=temperature, model_name=model_name, max_retries=5)
-    elif "claude" in model_name:
-        chat = Anthropic(model=model_name, temperature=temperature)
-    else:
-        raise ValueError("Unknown model name %s" % model_name)
-
+    chat = ChatLiteLLM(temperature=temperature, model_name=model_name, max_retries=5)
     results = []
     for prompt in tqdm(prompts):
         print(f"A is {prompt['A']}, B is {prompt['B']}")


### PR DESCRIPTION
This PR adds support for 50+ models using liteLLM : https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the ChatOpenAI I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```